### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -6,6 +6,8 @@ on:
   repository_dispatch:
     types:
       - banking-release-updated
+permissions:
+  contents: write
 jobs:
   insert-and-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/narmi/public-api-sdk-ts/security/code-scanning/4](https://github.com/narmi/public-api-sdk-ts/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the actions performed in the workflow, the following permissions are necessary:
- `contents: write` for committing changes and pushing tags.
- `issues: write` or `pull-requests: write` if the workflow interacts with issues or pull requests (not explicitly seen here).
- `actions: read` for downloading artifacts or listing workflows (if applicable).
- `packages: read` for interacting with packages (if applicable).

The permissions block should be added at the root level of the workflow file to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
