### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/toolchain-sanity-check.yml
+++ b/.github/workflows/toolchain-sanity-check.yml
@@ -2,6 +2,8 @@ name: Build Sanity Check
 
 on:
   pull_request:
+permissions:
+  contents: read
 jobs:
   client-generation-sanity-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/narmi/public-api-sdk-ts/security/code-scanning/5](https://github.com/narmi/public-api-sdk-ts/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily reads repository contents and does not perform write operations, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `client-generation-sanity-check` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
