### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -31,20 +33,26 @@ jobs:
       run: npm install --include=dev
 
     - name: Run command to insert files
+      env:
+        SCHEMA_FILENAME: ${{ github.event.client_payload.filename }}
       run: |
         npm run remove-sdk
-        curl -o public.yml "https://apidocs-narmi.s3.amazonaws.com/public/${{ github.event.client_payload.filename }}"
+        curl -o public.yml "https://apidocs-narmi.s3.amazonaws.com/public/${SCHEMA_FILENAME}"
         npm run generate-sdk
         npm run remove-schema
 
     - name: Commit changes
+      env:
+        API_VERSION: ${{ github.event.client_payload.api_version }}
+        GITHUB_ACTOR_NAME: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config --local user.name "github-actions[bot]"
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         npm run git-add-sdk
-        git commit -am "Build triggered by ${{ github.actor }} on $(date +"%Y-%m-%d %H:%M:%S")"
-        git tag ${{ github.event.client_payload.api_version }}
-        git push origin ${{ github.event.client_payload.api_version }}
+        git commit -am "Build triggered by ${GITHUB_ACTOR_NAME} on $(date +"%Y-%m-%d %H:%M:%S")"
+        git tag "${API_VERSION}"
+        git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${API_VERSION}"
     - name: Create Release
       id: create_release
       uses: comnoco/create-release-action@7dea6dc82ac9d97ced7a764aa82811451bba80e0 # v2

--- a/.github/workflows/toolchain-sanity-check.yml
+++ b/.github/workflows/toolchain-sanity-check.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4


### PR DESCRIPTION
## Summary
- Disable persisted checkout credentials in GitHub Actions workflows
- Move event-derived values into environment variables before shell use to avoid template injection
- Authenticate the release tag push explicitly after disabling checkout credential persistence

## Verification
- `zizmor .`